### PR TITLE
adding data persistence for DiscussionThread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
-		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -52,11 +50,18 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/D2lMockApplication.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/D2lMockApplication.java
@@ -1,13 +1,25 @@
 package edu.depaul.cdm.se452.d2l_mock;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import edu.depaul.cdm.se452.d2l_mock.discussion_thread.DiscussionThreadRepository;
+import edu.depaul.cdm.se452.d2l_mock.discussion_thread.DiscussionThread;
 
 @SpringBootApplication
 public class D2lMockApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(D2lMockApplication.class, args);
+	}
+
+	@Bean
+	CommandLineRunner addDiscussionThreadUserRun(DiscussionThreadRepository threadRepo) {
+		return args -> {
+			threadRepo.save(DiscussionThread.builder().title("Discussion Thread 1").build());
+		};
 	}
 
 }

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThread.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThread.java
@@ -1,7 +1,13 @@
 package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,13 +19,18 @@ import lombok.NoArgsConstructor;
  * and instructors.
  */
 @Data
+@Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class DiscussionThread {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
     private String title;
-    private Poster author;
-    private LocalDateTime createdAt;
     private String subject;
-    private Post[] posts;
+
+    @OneToMany(fetch = FetchType.EAGER)
+    private List<Post> posts;
 }

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepository.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepository.java
@@ -1,0 +1,10 @@
+package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for DiscussionThread objects
+ */
+public interface DiscussionThreadRepository extends JpaRepository<DiscussionThread, Long> {
+
+}

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/Post.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/Post.java
@@ -1,7 +1,11 @@
 package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
-import java.time.LocalDateTime;
-
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,11 +15,17 @@ import lombok.NoArgsConstructor;
  * Post represents a post in a discussion thread.
  */
 @Data
+@Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Post {
-    private Poster author;
-    private LocalDateTime createdAt;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
     private String content;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    private DiscussionThread discussionThread;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,19 @@
+environment: development
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: DEBUG
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:d2l-mockdev;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL
+    driverClassName: org.h2.Driver
+  h2:
+    console.enabled: true
+
+  jpa:
+    # generate-ddl: true
+    show-sql: true
+    hibernate.ddl-auto: create-drop
+    defer-datasource-initialization: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+environment: production
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: DEBUG
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:d2l-mockprod;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL
+    driverClassName: org.h2.Driver
+
+  jpa:
+    defer-datasource-initialization: true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=d2l-mock

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+app:
+  doc:
+    version: 2024-Fall
+    title: SE452 D2l Mock
+    description: This is a configuration file for the SE452 D2l Mock
+    terms-of-service: http://swagger.io/terms/
+    license:  Apache 2.0
+    url: http://springdoc.org
+
+spring:
+  profiles:
+    active: dev

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,15 @@
+insert into
+    discussion_thread(title, subject)
+values
+    (
+        'First Thread',
+        'This is the first thread'
+    );
+
+insert into
+    discussion_thread(title, subject)
+values
+    (
+        'Second Thread',
+        'This is the second thread'
+    );

--- a/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadTest.java
+++ b/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadTest.java
@@ -1,43 +1,20 @@
 package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import edu.depaul.cdm.se452.d2l_mock.Student;
 
 public class DiscussionThreadTest {
     @DisplayName("Test DiscussionThread instantiation")
     @Test
     public void testDiscussionThreadInstantiation() {
-        // Create author
-        Student author = new Student();
-        author.setFirstName("Doc");
-        author.setLastName("Holliday");
-
         // Create DiscussionThread
         DiscussionThread discussionThread = new DiscussionThread();
-        LocalDateTime createdAt = LocalDateTime.now();
         discussionThread.setTitle("Test Title");
-        discussionThread.setAuthor(author);
-        discussionThread.setCreatedAt(createdAt);
         discussionThread.setSubject("A Subject about SE452");
 
-        // Create Post
-        Post post = new Post();
-        post.setAuthor(author);
-        post.setCreatedAt(LocalDateTime.now());
-        post.setContent("This is the Reply to the Discussion Thread");
-
-        Post[] posts = { post };
-
-        discussionThread.setPosts(posts);
-
-        String expectedString = "DiscussionThread(title=Test Title, author=Student(birthdate=null, StudentID=0, firstName=Doc, lastName=Holliday, isAdmin=false), createdAt="
-                + createdAt
-                + ", subject=A Subject about SE452, posts=[Post(author=Student(birthdate=null, StudentID=0, firstName=Doc, lastName=Holliday, isAdmin=false), createdAt="
-                + post.getCreatedAt() + ", content=This is the Reply to the Discussion Thread)])";
+        String expectedString = "DiscussionThread(id=0, title=Test Title, subject=A Subject about SE452, posts=null)";
 
         assertEquals(expectedString, discussionThread.toString());
     }

--- a/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostTest.java
+++ b/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostTest.java
@@ -5,30 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import java.time.LocalDateTime;
-
-import edu.depaul.cdm.se452.d2l_mock.Student;
 
 public class PostTest {
     @DisplayName("Testing Post class instantiation")
     @Test
     public void testPostInstantiation() {
-        // Create author
-        Student author = new Student();
-        author.setFirstName("John");
-        author.setLastName("Virginia");
-
-        // Create Post
-        LocalDateTime createdAt = LocalDateTime.now();
         Post post = new Post();
-        post.setAuthor(author);
-        post.setCreatedAt(createdAt);
         post.setContent("This is a reply to a discussion thread");
 
         assertNotNull(post);
 
-        String expectedString = "Post(author=Student(birthdate=null, StudentID=0, firstName=John, lastName=Virginia, isAdmin=false), createdAt="
-                + createdAt + ", content=This is a reply to a discussion thread)";
+        String expectedString = "Post(id=0, content=This is a reply to a discussion thread, discussionThread=null)";
 
         assertEquals(expectedString, post.toString());
     }


### PR DESCRIPTION
Setting Up Initial H2 Configurations and Data Persistence for The Discussion Thread and Posts. The work for Discussion Thread and Post is not completely done by this PR but this PR allows the team to move forward with the initial set up.