### PR TITLE
Adding additional logic for max points

### DIFF
--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadController.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.cache.annotation.Cacheable;
 
 @Controller
 @RequestMapping("/discussion-threads")
@@ -19,7 +18,6 @@ public class DiscussionThreadController {
     private DiscussionThreadService threadService;
 
     @GetMapping
-    @Cacheable(value = "discussion-threads")
     public String list(Model model) {
         List<DiscussionThread> threads = threadService.list();
         model.addAttribute("threads", threads);

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepository.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepository.java
@@ -1,10 +1,12 @@
 package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Repository for DiscussionThread objects
  */
 public interface DiscussionThreadRepository extends JpaRepository<DiscussionThread, Long> {
-
+    List<DiscussionThread> findByStudentId(Long studentId);
 }

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostRepository.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostRepository.java
@@ -1,7 +1,9 @@
 package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-
+    List<Post> findByStudentId(long studentId);
 }

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/package-info.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/package-info.java
@@ -10,13 +10,19 @@
  * thread
  * <ul>
  * <li>UI for listing Discussion Threads and creating new Discussion
- * Threads
+ * Threads. Ken noted via email that this can be used as Non-Persistence not
+ * discussed in class.
  * <li>UI for showing a single Discussion Thread and adding a Post to a
- * Discussion Thread
+ * Discussion Thread. Ken noted via email that this can be used as
+ * Non-Persistence not discussed in class.
+ * <li>Added Repositories for Discussion Thread and Post classes
  * <li>Added unit tests to demonstrate repositories working
  * <li>Added unit tests to demonstrate services working
  * <li>Added unit tests to demonstrate controllers working
  * <li>Added logging in Both Discussion Thread and Post Service Classes
+ * <li>Added additional finder for PostRepository to find by StudentId
+ * <li>Added additional finder for DiscussionThreadRepository to find by
+ * StudentId
  * </ul>
  * 
  * @author John Richmond

--- a/src/main/java/edu/depaul/cdm/se452/d2l_mock/submission/service/AssignmentServiceImpl.java
+++ b/src/main/java/edu/depaul/cdm/se452/d2l_mock/submission/service/AssignmentServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import edu.depaul.cdm.se452.d2l_mock.submission.AssignmentRepository;
 import edu.depaul.cdm.se452.d2l_mock.submission.dto.AssignmentDTO;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import edu.depaul.cdm.se452.d2l_mock.course.Course;
 import edu.depaul.cdm.se452.d2l_mock.course.CourseRepository;
 import edu.depaul.cdm.se452.d2l_mock.student.Student;

--- a/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepositoryTest.java
+++ b/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/DiscussionThreadRepositoryTest.java
@@ -2,6 +2,8 @@ package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
 import edu.depaul.cdm.se452.d2l_mock.student.Student;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -34,5 +36,13 @@ public class DiscussionThreadRepositoryTest {
 
         thread1.getPosts().add(newPost);
         discussionThreadRepo.save(thread1);
+    }
+
+    @Test
+    void testFindByStudentId() {
+        List<DiscussionThread> threads = discussionThreadRepo.findByStudentId(1L);
+        assertEquals(1, threads.size());
+        assertEquals("First Thread", threads.get(0).getTitle());
+        assertEquals("This is the first thread", threads.get(0).getSubject());
     }
 }

--- a/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostRepositoryTest.java
+++ b/src/test/java/edu/depaul/cdm/se452/d2l_mock/discussion_thread/PostRepositoryTest.java
@@ -2,6 +2,8 @@ package edu.depaul.cdm.se452.d2l_mock.discussion_thread;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,5 +27,11 @@ public class PostRepositoryTest {
         String postContent = postRepo.findById(post.getId()).get().getContent();
         String expectedContent = "This is my 6th post! Check data.sql for the other 5 posts.";
         assertEquals(expectedContent, postContent);
+    }
+
+    @Test
+    public void testFindByStudentId() {
+        List<Post> posts = postRepo.findByStudentId(1L);
+        assertEquals(3, posts.size());
     }
 }

--- a/src/test/java/edu/depaul/cdm/se452/d2l_mock/student/StudentServiceTest.java
+++ b/src/test/java/edu/depaul/cdm/se452/d2l_mock/student/StudentServiceTest.java
@@ -1,8 +1,5 @@
 package edu.depaul.cdm.se452.d2l_mock.student;
 
-
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;


### PR DESCRIPTION
This PR Does the following 

* Removes Caching Code that is no longer relevant
* Makes Threads and Posts searchable by StudentID
* Updates the `discussion_thread` package-info file to reflect all changes
* Removes code that cause warnings